### PR TITLE
Fix body scroll after close modal via click on the backdrop

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -95,5 +95,7 @@ document.addEventListener('DOMContentLoaded', function () {
   overlay.addEventListener('click', function () {
     document.querySelector('.modal.active').classList.remove('active');
     this.classList.remove('active');
+    // Prevent body scroll when modal is open
+    body.classList.remove('no-scroll');
   });
 }); // end ready


### PR DESCRIPTION
Пофіксив, щоб скрол на боді працював після закриття модалки по кліку на бекдропі.